### PR TITLE
Remove name configuration.

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,4 +1,3 @@
-name: drupal-recommended-project
 type: drupal9
 docroot: web
 php_version: "7.4"


### PR DESCRIPTION
Do not set the `name` configuration value for DDEV projects, it prevents additional instances from being spun up in parallel (e.g. prevents multiple branches from being worked on simultaneously).